### PR TITLE
Make package ready for 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "dyaa/pushover",
-    "description": "Laravel 4.2 Pushover Package",
+    "description": "Laravel >= 4.2 Pushover Package",
     "keywords": ["laravel", "pushover", "Real Time", "notification","Artisan","CLI","Command"],
     "license": "MIT",
     "version": "1.3.1",
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.2.*"
+        "illuminate/support": "~4.2"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Let's require Laravel 4.2 or higher, so we can use the package with Laravel 4.3 from day 1.
