### PR TITLE
Added function to allow changing the user key

### DIFF
--- a/src/Dyaa/Pushover/Pushover.php
+++ b/src/Dyaa/Pushover/Pushover.php
@@ -86,6 +86,11 @@ class Pushover
         $this->retry = $retry;
         $this->expire = $expire;
     }
+    
+    public function user($user_key)
+    {
+        $this->user_key = $user_key;
+    }
 
     public function send()
     {


### PR DESCRIPTION
In the context of using Pushover for application status notifications for the devs/webmasters, having the user key in the configuration makes sense. However, for applications that use Pushover to send notifications to the users, as in #8, this doesn't make as much sense.

This change adds a function that will allow the user token to be dynamically set at run time. 