### PR TITLE
Added html support. Defaults to true.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ To Set a Device Name (Optional)
 ```php
 Pushover::device($device);
 ```
+To Set if the Message should be sent as HTML (Optional) Default is 1
+```php
+Pushover::html($html);
+```
 To Set a Timestamp (Optional) Default is *time()*
 ```php
 Pushover::timestamp($timestamp);

--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ to set a priority expire *(in seconds)* Default is **356**  *"Optional"*
 
     --expire=356
 
+to set if message should be sent as HTML. Default is **1**  *"Optional"*
+*Note: Message body needs to be wrapped in quotes.*
+
+    --html=1
+
 ----------
 
 

--- a/src/Dyaa/Pushover/Commands/PushoverCommand.php
+++ b/src/Dyaa/Pushover/Commands/PushoverCommand.php
@@ -133,6 +133,7 @@ class PushoverCommand extends Command {
             ['priority', null, InputOption::VALUE_OPTIONAL, 'Set a Priority Message.', null],
             ['retry', null, InputOption::VALUE_OPTIONAL, 'Set a Retry for the Priority.', null],
             ['expire', null, InputOption::VALUE_OPTIONAL, 'Set an expire for the Priority.', null],
+            ['html', null, InputOption::VALUE_OPTIONAL, 'Sets if message should be sent as HTML.', null],
             ['debug', null, InputOption::VALUE_NONE, 'Turn the Debug Mode.', null],
         ];
     }

--- a/src/Dyaa/Pushover/Commands/PushoverCommand.php
+++ b/src/Dyaa/Pushover/Commands/PushoverCommand.php
@@ -48,6 +48,7 @@ class PushoverCommand extends Command {
         $priority   = $this->option('priority');
         $retry      = $this->option('retry');
         $expire     = $this->option('expire');
+        $html       = $this->option('html');
 
         if (!isset($retry)) {
             $retry = 60;
@@ -55,6 +56,10 @@ class PushoverCommand extends Command {
 
         if (!isset($expire)) {
             $expire = 365;
+        }
+
+        if(!isset($html)) {
+            $html = 1;
         }
 
         if (!isset($urltitle)) {
@@ -71,6 +76,9 @@ class PushoverCommand extends Command {
             $this->push->sound($sound);
         }
 
+        if ($html) {
+            $this->push->html($html);
+        }
         // if device var is set
         if ($device) {
             $this->push->device($device);

--- a/src/Dyaa/Pushover/Pushover.php
+++ b/src/Dyaa/Pushover/Pushover.php
@@ -20,6 +20,7 @@ class Pushover
     private $expire;
     private $title;
     private $msg;
+    private $html = 1;
 
     public function __construct(Repository $config)
     {
@@ -72,6 +73,11 @@ class Pushover
         $this->device = $device;
     }
 
+    public function html($html)
+    {
+        $this->html = $html;
+    }
+
     public function timestamp($timestamp = null)
     {
         if ($timestamp == null) {
@@ -106,6 +112,7 @@ class Pushover
             'message'   => $this->msg,
             'device'    => $this->device,
             'timestamp' => $this->timestamp,
+            'html'      => $this->html,
             'callback'  => $this->callback,
             'sound'     => $this->sound,
             'url'       => $this->url,


### PR DESCRIPTION
“As of version 2.3 of our device clients, messages can be formatted with HTML tags.
To enable HTML formatting, include an html parameter set to 1. The normal message content in your message parameter will then be displayed as HTML.”